### PR TITLE
Highlight, Tile Selection, and Wind Current Fixes

### DIFF
--- a/Capstone Project/Assets/Scripts/GridScripts/GridManager.cs
+++ b/Capstone Project/Assets/Scripts/GridScripts/GridManager.cs
@@ -19,6 +19,7 @@ public class GridManager : MonoBehaviour
     // -5 is a pip occupied tile
     // -6 is a hazard occupied tile
     //-7 is a shield occupied tile
+    //-8 is a wind current occupied tile
     public static TileBehaviour[,] combatGrid;
 
     public static Vector2Int playerPosition;
@@ -89,7 +90,8 @@ public class GridManager : MonoBehaviour
                 combatGrid[tileCoordinates.x, tileCoordinates.y].entityOnGrid == -6;
         }
         return combatGrid[tileCoordinates.x, tileCoordinates.y].entityOnGrid == -1 ||
-            combatGrid[tileCoordinates.x, tileCoordinates.y].entityOnGrid == -6;
+            combatGrid[tileCoordinates.x, tileCoordinates.y].entityOnGrid == -6 ||
+            combatGrid[tileCoordinates.x, tileCoordinates.y].entityOnGrid == -8;
     }
 
     /// <summary>

--- a/Capstone Project/Assets/Scripts/GridScripts/WindCurrentTracker.cs
+++ b/Capstone Project/Assets/Scripts/GridScripts/WindCurrentTracker.cs
@@ -135,7 +135,8 @@ public class WindCurrentTracker : MonoBehaviour
             }
             else
             {
-                return newTile.entityOnGrid == -1 || newTile.entityOnGrid == -4 || newTile.entityOnGrid == -20;
+                return newTile.entityOnGrid == -1 || newTile.entityOnGrid == -4 || newTile.entityOnGrid == -8 || 
+                newTile.entityOnGrid == -20;
             }
 
         }
@@ -154,6 +155,8 @@ public class WindCurrentTracker : MonoBehaviour
     /// <param name="enemy"> the enemy that is "hit" </param>
     void SendEnemyBackwards(TileBehaviour originTile, TileBehaviour enemyTile, Enemy enemy)
     {
+
+        WindCurrentTracker[] trackers = FindObjectsByType<WindCurrentTracker>(FindObjectsSortMode.None);
 
         Vector2Int newTilePos = enemyTile.IndexInGrid;
 
@@ -213,6 +216,23 @@ public class WindCurrentTracker : MonoBehaviour
                 else if (newTile.entityOnGrid == -4)
                 {
                     enemy.Damage(CurrentKBDamage, Enemy.DamageType.Wind);
+                }
+                else if (newTile.entityOnGrid == -8)
+                {
+
+                    foreach (WindCurrentTracker tracker in trackers)
+                    {
+
+                        if (tracker.WindCurrentTiles.Contains(newTile) && tracker != this)
+                        {
+
+                            enemy.Damage(tracker.CurrentDamage, Enemy.DamageType.Wind);
+                            tracker.SendThroughWindCurrent(tracker.WindCurrentTiles.IndexOf(newTile), enemy);
+
+                        }
+
+                    }
+
                 }
 
                 break;

--- a/Capstone Project/Assets/Scripts/Player/PlayerBehavior.cs
+++ b/Capstone Project/Assets/Scripts/Player/PlayerBehavior.cs
@@ -179,7 +179,6 @@ public class PlayerBehavior : MonoBehaviour
         ShieldBehavior[] allShields = FindObjectsByType<ShieldBehavior>(FindObjectsSortMode.None);
         if(allShields.Length >= 1)
         {
-
             foreach(ShieldBehavior shield in allShields)
             {
 
@@ -187,18 +186,18 @@ public class PlayerBehavior : MonoBehaviour
                 shield.GetDestroyed();
 
             }
-
         }
 
         WindCurrentTracker[] allCurrents = FindObjectsByType<WindCurrentTracker>(FindObjectsSortMode.None);
         if (allCurrents.Length >= 1)
         {
-
             foreach (WindCurrentTracker current in allCurrents)
             {
-
+                foreach(TileBehaviour tile in current.WindCurrentTiles)
+                {
+                    GridManager.RemoveEntity(tile.IndexInGrid);
+                }
                 current.DestroyCurrents();
-
             }
 
         }

--- a/Capstone Project/Assets/Scripts/Player/PlayerBehavior.cs
+++ b/Capstone Project/Assets/Scripts/Player/PlayerBehavior.cs
@@ -193,6 +193,7 @@ public class PlayerBehavior : MonoBehaviour
         {
             foreach (WindCurrentTracker current in allCurrents)
             {
+
                 foreach(TileBehaviour tile in current.WindCurrentTiles)
                 {
                     GridManager.RemoveEntity(tile.IndexInGrid);

--- a/Capstone Project/Assets/Scripts/Runes/RuneEvents.cs
+++ b/Capstone Project/Assets/Scripts/Runes/RuneEvents.cs
@@ -1507,6 +1507,7 @@ public class RuneEvents : MonoBehaviour
                 {
 
                     currentTracker.WindCurrentTiles.Add(GridManager.combatGrid[PreviousPos[i].x, PreviousPos[i].y]);
+                    GridManager.AddEntity(PreviousPos[i], -8);
 
                     if(i == movementPos.Count - 1)
                     {

--- a/Capstone Project/Assets/Scripts/Runes/RuneEvents.cs
+++ b/Capstone Project/Assets/Scripts/Runes/RuneEvents.cs
@@ -1093,6 +1093,36 @@ public class RuneEvents : MonoBehaviour
     }
 
     /// <summary>
+    /// checks if a tile is already housing a wind current
+    /// temporary solution? there's some stuff i should discuss with people in person methinks
+    /// </summary>
+    /// <param name="tileCoordinates"> tile that the player is trying to path on </param>
+    /// <returns> whether or not the tile has a wind current placed on it </returns>
+    public static bool HasWindCurrent(Vector2Int tileCoordinates)
+    {
+
+        WindCurrentTracker[] allCurrents = FindObjectsByType<WindCurrentTracker>(FindObjectsSortMode.None);
+
+        if(allCurrents.Length >= 1)
+        {
+            //sorry this is evil
+            foreach(WindCurrentTracker current in allCurrents)
+            {
+                foreach(TileBehaviour tile in current.WindCurrentTiles)
+                {
+                    if(tile.IndexInGrid == tileCoordinates)
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+
+    }
+
+    /// <summary>
     /// determines where the player is attempting to path
     /// </summary>
     /// <param name="dir"> the direction that the player moves in </param>
@@ -1317,7 +1347,8 @@ public class RuneEvents : MonoBehaviour
 
                     default:
 
-                        if (GridManager.combatGrid[v.x, v.y].GetComponentInChildren<PlayerBehavior>())
+                        if (GridManager.combatGrid[v.x, v.y].GetComponentInChildren<PlayerBehavior>() ||
+                        (selectedRune.NumberOnSkillTree == 3 && HasWindCurrent(v)))
                         {
 
                             StartCoroutine(MovementDelay());

--- a/Capstone Project/Assets/Scripts/Runes/RuneEvents.cs
+++ b/Capstone Project/Assets/Scripts/Runes/RuneEvents.cs
@@ -1093,36 +1093,6 @@ public class RuneEvents : MonoBehaviour
     }
 
     /// <summary>
-    /// checks if a tile is already housing a wind current
-    /// temporary solution? there's some stuff i should discuss with people in person methinks
-    /// </summary>
-    /// <param name="tileCoordinates"> tile that the player is trying to path on </param>
-    /// <returns> whether or not the tile has a wind current placed on it </returns>
-    public static bool HasWindCurrent(Vector2Int tileCoordinates)
-    {
-
-        WindCurrentTracker[] allCurrents = FindObjectsByType<WindCurrentTracker>(FindObjectsSortMode.None);
-
-        if(allCurrents.Length >= 1)
-        {
-            //sorry this is evil
-            foreach(WindCurrentTracker current in allCurrents)
-            {
-                foreach(TileBehaviour tile in current.WindCurrentTiles)
-                {
-                    if(tile.IndexInGrid == tileCoordinates)
-                    {
-                        return true;
-                    }
-                }
-            }
-        }
-
-        return false;
-
-    }
-
-    /// <summary>
     /// determines where the player is attempting to path
     /// </summary>
     /// <param name="dir"> the direction that the player moves in </param>
@@ -1347,8 +1317,7 @@ public class RuneEvents : MonoBehaviour
 
                     default:
 
-                        if (GridManager.combatGrid[v.x, v.y].GetComponentInChildren<PlayerBehavior>() ||
-                        (selectedRune.NumberOnSkillTree == 3 && HasWindCurrent(v)))
+                        if (GridManager.combatGrid[v.x, v.y].GetComponentInChildren<PlayerBehavior>())
                         {
 
                             StartCoroutine(MovementDelay());

--- a/Capstone Project/Assets/Scripts/Runes/RuneEvents.cs
+++ b/Capstone Project/Assets/Scripts/Runes/RuneEvents.cs
@@ -16,6 +16,7 @@ using static Unity.Collections.Unicode;
 using FMOD.Studio;
 using FMODUnity;
 using EventReference = FMODUnity.EventReference;
+using Unity.VisualScripting;
 
 
 public class RuneEvents : MonoBehaviour
@@ -922,7 +923,7 @@ public class RuneEvents : MonoBehaviour
             }
             else
             {
-                return newTile.entityOnGrid == -1 || newTile.entityOnGrid == -20;
+                return newTile.entityOnGrid == -1 || newTile.entityOnGrid == -20 || newTile.entityOnGrid == -8;
             }
 
         }
@@ -941,6 +942,8 @@ public class RuneEvents : MonoBehaviour
     /// <param name="target"> the target </param>
     void SendEnemyBackwards(TileBehaviour kbSource, TileBehaviour kbTarget, Enemy target)
     {
+
+        WindCurrentTracker[] trackers = FindObjectsByType<WindCurrentTracker>(FindObjectsSortMode.None);
 
         Vector2Int newTilePos = kbTarget.IndexInGrid;
 
@@ -972,20 +975,7 @@ public class RuneEvents : MonoBehaviour
 
                 newTile = GridManager.combatGrid[newTilePos.x, newTilePos.y];
 
-                if (newTile.entityOnGrid == -1 || newTile.entityOnGrid == -20)
-                {
-
-                    target.transform.SetParent(newTile.transform);
-
-                    target.transform.position = new Vector3(newTile.transform.position.x, 0, newTile.transform.position.z);
-
-                    GridManager.MoveToTile(kbTarget.IndexInGrid, newTilePos, -2);
-
-                    target.GetComponent<GridPathfinding>().SetPosition(newTilePos);
-                    FindFirstObjectByType<PlayerBehavior>().UpdateEnemyPositions();
-
-                }
-                else if (newTile.entityOnGrid == -2)
+                if (newTile.entityOnGrid == -2)
                 {
 
                     newTile.GetComponentInChildren<Enemy>().Damage(currentSecondaryDamage, Enemy.DamageType.Wind);
@@ -1002,13 +992,36 @@ public class RuneEvents : MonoBehaviour
                     FindFirstObjectByType<PlayerBehavior>().UpdateEnemyPositions();
 
                 }
+                else
+                {
 
-                break;
+                    target.transform.SetParent(newTile.transform);
 
+                    target.transform.position = new Vector3(newTile.transform.position.x, 0, newTile.transform.position.z);
+
+                    GridManager.MoveToTile(kbTarget.IndexInGrid, newTilePos, -2);
+
+                    target.GetComponent<GridPathfinding>().SetPosition(newTilePos);
+                    FindFirstObjectByType<PlayerBehavior>().UpdateEnemyPositions();
+
+                    foreach (WindCurrentTracker tracker in trackers)
+                    {
+
+                        if (tracker.WindCurrentTiles.Contains(newTile))
+                        {
+
+                            target.Damage(tracker.CurrentDamage, Enemy.DamageType.Wind);
+                            tracker.SendThroughWindCurrent(tracker.WindCurrentTiles.IndexOf(newTile), target);
+
+                        }
+
+                    }
+
+                }
+
+                    break;
             }
-
         }
-
     }
 
     /// <summary>
@@ -1082,12 +1095,21 @@ public class RuneEvents : MonoBehaviour
     /// </summary>
     /// <param name="tileCoordinates"> the tile that the player is attempting to highlight </param>
     /// <returns> status of a tile </returns>
-    public static bool CanMoveThroughTile(Vector2Int tileCoordinates)
+    bool CanMoveThroughTile(Vector2Int tileCoordinates)
     {
 
+        if(selectedRune.TypeOfRune == RuneType.Wind && selectedRune.NumberOnSkillTree == 3)
+        {
+            return GridManager.combatGrid[tileCoordinates.x, tileCoordinates.y].entityOnGrid == -1 ||
+            GridManager.combatGrid[tileCoordinates.x, tileCoordinates.y].entityOnGrid == -2 ||
+            GridManager.combatGrid[tileCoordinates.x, tileCoordinates.y].entityOnGrid == -3 ||
+            GridManager.combatGrid[tileCoordinates.x, tileCoordinates.y].entityOnGrid == -20;
+        }
+        
         return GridManager.combatGrid[tileCoordinates.x, tileCoordinates.y].entityOnGrid == -1 ||
         GridManager.combatGrid[tileCoordinates.x, tileCoordinates.y].entityOnGrid == -2 ||
         GridManager.combatGrid[tileCoordinates.x, tileCoordinates.y].entityOnGrid == -3 ||
+        GridManager.combatGrid[tileCoordinates.x, tileCoordinates.y].entityOnGrid == -8 ||
         GridManager.combatGrid[tileCoordinates.x, tileCoordinates.y].entityOnGrid == -20;
 
     }
@@ -1372,6 +1394,8 @@ public class RuneEvents : MonoBehaviour
     void MoveAlongPath(RuneData rune)
     {
 
+        WindCurrentTracker[] trackers = FindObjectsByType<WindCurrentTracker>(FindObjectsSortMode.None);
+
         float damageDealt = 0;
 
         if(rune.TypeOfRune == RuneType.Wind)
@@ -1465,6 +1489,29 @@ public class RuneEvents : MonoBehaviour
 
                     if(i == (movementPos.Count - 1))
                     {
+
+                        foreach (WindCurrentTracker tracker in trackers)
+                        {
+
+                            if (tracker.WindCurrentTiles.Contains(GridManager.combatGrid[nextPos.x, nextPos.y]))
+                            {
+
+                                selectedEnemy.Damage(tracker.CurrentDamage, Enemy.DamageType.Wind);
+
+                                tracker.SendThroughWindCurrent(tracker.WindCurrentTiles.IndexOf
+                                (GridManager.combatGrid[nextPos.x, nextPos.y]), selectedEnemy);
+
+                                PreviousPos.Clear();
+                                movementPos.Clear();
+                                movementUsed = 0;
+
+                                StartCoroutine(UpdatePlayerStatus());
+
+                                return;
+
+                            }
+
+                        }
 
                         selectedEnemy.transform.SetParent(GridManager.combatGrid[nextPos.x, nextPos.y].transform);
 

--- a/Capstone Project/Assets/Scripts/Runes/RuneRangeAndTargeting.cs
+++ b/Capstone Project/Assets/Scripts/Runes/RuneRangeAndTargeting.cs
@@ -35,7 +35,7 @@ public class RuneRangeAndTargeting : MonoBehaviour
 
     private List<Enemy> enemiesInRange = new List<Enemy>();
 
-    [SerializeField] private Button confirm; 
+    [SerializeField] private Button confirm;
 
     [Header("Highlight Colors")]
     public Color DefaultHighlight;
@@ -563,20 +563,14 @@ public class RuneRangeAndTargeting : MonoBehaviour
     /// <param name="newTile"> the player's selected tile </param>
     public void EditViableTiles(bool addingToTiles, TileBehaviour newTile)
     {
-
         if(addingToTiles)
         {
-
             viableTilesInRange.Add(newTile);
-
         }
         else
         {
-
             viableTilesInRange.Remove(newTile);
-
         }
-
     }
 
     [HideInInspector] public TileBehaviour selectedTile;
@@ -703,6 +697,12 @@ public class RuneRangeAndTargeting : MonoBehaviour
     public void OnSpellCastConfirm()
     {
 
+        //i <3 rare bugs
+        if(this.gameObject.GetComponent<RuneEvents>().Casting)
+        {
+            return;
+        }
+
         switch (storedData.TypeOfRune)
         {
 
@@ -732,11 +732,13 @@ public class RuneRangeAndTargeting : MonoBehaviour
 
     #region END TURN
 
+    /// <summary>
+    /// determines if the player has spent any action points
+    /// </summary>
+    /// <param name="werePointsSpent"> whether or not points were spent </param>
     public void SetCastStatus(bool werePointsSpent)
     {
-
         castNotCanceled = werePointsSpent;
-
     }
 
     /// <summary>
@@ -776,8 +778,6 @@ public class RuneRangeAndTargeting : MonoBehaviour
         }
 
         GridManager.RemoveHighlight();
-
-        //this.gameObject.SetActive(false);
 
     }
 

--- a/Capstone Project/Assets/Scripts/Runes/RuneRangeAndTargeting.cs
+++ b/Capstone Project/Assets/Scripts/Runes/RuneRangeAndTargeting.cs
@@ -129,7 +129,7 @@ public class RuneRangeAndTargeting : MonoBehaviour
     /// </summary>
     /// <param name="tileCoordinates"> the tile that the player has selected </param>
     /// <returns> whether or not the tile can be targeted </returns>
-    public static bool CanAttackTile(Vector2Int tileCoordinates)
+    public static bool CanAttackThroughTile(Vector2Int tileCoordinates)
     {
 
         if (tileCoordinates == GridManager.playerPosition)
@@ -145,6 +145,20 @@ public class RuneRangeAndTargeting : MonoBehaviour
     }
 
     /// <summary>
+    /// checks if a tile should be actually targetable with a spell
+    /// </summary>
+    /// <param name="tileCoordinates"> the tile being checked </param>
+    /// <returns> whether or not the tile can be targeted </returns>
+    public static bool CanAttackTile(Vector2Int tileCoordinates)
+    {
+
+        return GridManager.combatGrid[tileCoordinates.x, tileCoordinates.y].entityOnGrid == -1 ||
+            GridManager.combatGrid[tileCoordinates.x, tileCoordinates.y].entityOnGrid == -2 ||
+            GridManager.combatGrid[tileCoordinates.x, tileCoordinates.y].entityOnGrid == -6;
+
+    }
+
+    /// <summary>
     /// creates a list of all targetable tiles upon selecting a spell
     /// </summary>
     /// <param name="currentTile"> the tile that the player has selected </param>
@@ -153,19 +167,19 @@ public class RuneRangeAndTargeting : MonoBehaviour
     {
         List<Vector2Int> validTiles = new List<Vector2Int>();
 
-        if (GridManager.TileIsInGrid(new Vector2Int(currentTile.x + 1, currentTile.y)) && CanAttackTile(new Vector2Int(currentTile.x + 1, currentTile.y)))
+        if (GridManager.TileIsInGrid(new Vector2Int(currentTile.x + 1, currentTile.y)) && CanAttackThroughTile(new Vector2Int(currentTile.x + 1, currentTile.y)))
         {
             validTiles.Add(new Vector2Int(currentTile.x + 1, currentTile.y));
         }
-        if (GridManager.TileIsInGrid(new Vector2Int(currentTile.x - 1, currentTile.y)) && CanAttackTile(new Vector2Int(currentTile.x - 1, currentTile.y)))
+        if (GridManager.TileIsInGrid(new Vector2Int(currentTile.x - 1, currentTile.y)) && CanAttackThroughTile(new Vector2Int(currentTile.x - 1, currentTile.y)))
         {
             validTiles.Add(new Vector2Int(currentTile.x - 1, currentTile.y));
         }
-        if (GridManager.TileIsInGrid(new Vector2Int(currentTile.x, currentTile.y + 1)) && CanAttackTile(new Vector2Int(currentTile.x, currentTile.y + 1)))
+        if (GridManager.TileIsInGrid(new Vector2Int(currentTile.x, currentTile.y + 1)) && CanAttackThroughTile(new Vector2Int(currentTile.x, currentTile.y + 1)))
         {
             validTiles.Add(new Vector2Int(currentTile.x, currentTile.y + 1));
         }
-        if (GridManager.TileIsInGrid(new Vector2Int(currentTile.x, currentTile.y - 1)) && CanAttackTile(new Vector2Int(currentTile.x, currentTile.y - 1)))
+        if (GridManager.TileIsInGrid(new Vector2Int(currentTile.x, currentTile.y - 1)) && CanAttackThroughTile(new Vector2Int(currentTile.x, currentTile.y - 1)))
         {
             validTiles.Add(new Vector2Int(currentTile.x, currentTile.y - 1));
         }
@@ -255,7 +269,10 @@ public class RuneRangeAndTargeting : MonoBehaviour
             foreach (Vector2Int tile in validTiles.ToList())
             {
 
-                tilesInRange.Add(GridManager.combatGrid[tile.x, tile.y]);
+                if(CanAttackTile(tile))
+                {
+                    tilesInRange.Add(GridManager.combatGrid[tile.x, tile.y]);
+                }
 
                 if (GridManager.combatGrid[tile.x, tile.y].entityOnGrid == -2)
                 {
@@ -329,7 +346,10 @@ public class RuneRangeAndTargeting : MonoBehaviour
             foreach (Vector2Int tile in validTiles.ToList())
             {
 
-                tilesInRange.Add(GridManager.combatGrid[tile.x, tile.y]);
+                if(CanAttackTile(tile))
+                {
+                    tilesInRange.Add(GridManager.combatGrid[tile.x, tile.y]);
+                }
 
             }
 
@@ -612,7 +632,7 @@ public class RuneRangeAndTargeting : MonoBehaviour
                 {
 
                     if (Mathf.Abs(tile.IndexInGrid.x - selectedTile.IndexInGrid.x) <= 1 &&
-                    Mathf.Abs(tile.IndexInGrid.y - selectedTile.IndexInGrid.y) <= 1 && !tile.GetComponentInChildren<PlayerBehavior>())
+                    Mathf.Abs(tile.IndexInGrid.y - selectedTile.IndexInGrid.y) <= 1 && CanAttackTile(tile.IndexInGrid))
                     {
 
                         tile.SetHighlightColor(LightningSecondaryHighlight);
@@ -630,7 +650,7 @@ public class RuneRangeAndTargeting : MonoBehaviour
                 {
 
                     if (selectedTile.transform.position.x == tile.transform.position.x &&
-                    Mathf.Abs(selectedTile.IndexInGrid.y - tile.IndexInGrid.y) <= storedData.RuneRange)
+                    Mathf.Abs(selectedTile.IndexInGrid.y - tile.IndexInGrid.y) <= storedData.RuneRange && CanAttackTile(tile.IndexInGrid))
                     {
 
                         tile.SetHighlightColor(LightningSecondaryHighlight);
@@ -639,7 +659,7 @@ public class RuneRangeAndTargeting : MonoBehaviour
                     }
 
                     if (selectedTile.transform.position.z == tile.transform.position.z &&
-                    Mathf.Abs(selectedTile.IndexInGrid.x - tile.IndexInGrid.x) <= storedData.RuneRange)
+                    Mathf.Abs(selectedTile.IndexInGrid.x - tile.IndexInGrid.x) <= storedData.RuneRange && CanAttackTile(tile.IndexInGrid))
                     {
 
                         tile.SetHighlightColor(LightningSecondaryHighlight);
@@ -657,7 +677,7 @@ public class RuneRangeAndTargeting : MonoBehaviour
                 {
 
                     if (Mathf.Abs(tile.IndexInGrid.x - selectedTile.IndexInGrid.x) <= 1 &&
-                    Mathf.Abs(tile.IndexInGrid.y - selectedTile.IndexInGrid.y) <= 1 && !tile.GetComponentInChildren<PlayerBehavior>())
+                    Mathf.Abs(tile.IndexInGrid.y - selectedTile.IndexInGrid.y) <= 1 && CanAttackTile(tile.IndexInGrid))
                     {
 
                         tile.SetHighlightColor(LightningSecondaryHighlight);


### PR DESCRIPTION
WHAT TO LOOK FOR:
- Pips cannot be targeted by spells. However, they do not block the player's range.
- Wind Currents cannot be stacked.
- Enemies can be knocked backwards into Wind Currents.
- The player should no longer be able to spam tile selection.
- The player cannot move onto Wind Current tiles.
- Tiles that cannot be targeted will no longer be highlighted by a spell's AOE preview. 