### PR TITLE
WASD above almond only shows when in tutorial lvl

### DIFF
--- a/Capstone Project/Assets/Scripts/GridScripts/GridTesting.cs
+++ b/Capstone Project/Assets/Scripts/GridScripts/GridTesting.cs
@@ -181,4 +181,13 @@ public class GridTesting : MonoBehaviour
         }
         entityLists.Clear();
     }
+
+    /// <summary>
+    /// Gets the grid index
+    /// </summary>
+    /// <returns></returns>
+    public int GetGridIndex()
+    {
+        return gridIndex;
+    }
 }

--- a/Capstone Project/Assets/Scripts/UI/InCombatMenu/WasdUIController.cs
+++ b/Capstone Project/Assets/Scripts/UI/InCombatMenu/WasdUIController.cs
@@ -12,6 +12,16 @@ public class WasdUIController : MonoBehaviour
     [SerializeField] private GameObject wasdObject;
     [SerializeField] private CanvasGroup canvasGroup;
 
+    private GridTesting gridTesting;
+
+    /// <summary>
+    /// On start initialization
+    /// </summary>
+    private void Start()
+    {
+        gridTesting = FindFirstObjectByType<GridTesting>();
+    }
+
     /// <summary>
     /// Subscribe to event
     /// </summary>
@@ -30,9 +40,14 @@ public class WasdUIController : MonoBehaviour
 
     /// <summary>
     /// Toggle if the WASD prompt is showing 
+    /// && its the tutorial level
     /// </summary>
     private void ToggleWasd()
     {
-        canvasGroup.alpha = canvasGroup.alpha == 0 ? 1 : 0; 
+        if(gridTesting.GetGridIndex() == 0)
+        {
+            canvasGroup.alpha = canvasGroup.alpha == 0 ? 1 : 0;
+        }
+        
     }
 }


### PR DESCRIPTION
The WASD above almonds head only appears in the tutorial lvl

Test in copy IB and move around lvls. Make sure when you click the move button on levels other then the tutorial the grey wasd doesn't show up 