### PR TITLE
added a delay for the end level menu

### DIFF
--- a/Capstone Project/Assets/PreFabs/UI/End Level Menu.prefab
+++ b/Capstone Project/Assets/PreFabs/UI/End Level Menu.prefab
@@ -302,6 +302,7 @@ MonoBehaviour:
   LoseMenu: {fileID: 1900362504874459754}
   IsDemo: 0
   demoMenu: {fileID: 5482779285567286091}
+  popupDelay: 0.5
 --- !u!1 &3332349209192235764
 GameObject:
   m_ObjectHideFlags: 0

--- a/Capstone Project/Assets/PreFabs/UI/End Level Menu.prefab
+++ b/Capstone Project/Assets/PreFabs/UI/End Level Menu.prefab
@@ -302,7 +302,7 @@ MonoBehaviour:
   LoseMenu: {fileID: 1900362504874459754}
   IsDemo: 0
   demoMenu: {fileID: 5482779285567286091}
-  popupDelay: 0.5
+  popupDelay: 3
 --- !u!1 &3332349209192235764
 GameObject:
   m_ObjectHideFlags: 0

--- a/Capstone Project/Assets/Scripts/UI/EndLevelMenu.cs
+++ b/Capstone Project/Assets/Scripts/UI/EndLevelMenu.cs
@@ -7,10 +7,9 @@ Brief Description : 		Temporary End Level Menu handler for
 External Resources : 	
 ***************************************************/
 using NUnit.Framework;
-using System.Collections.Generic;
+using System.Collections;
 using TMPro;
 using UnityEngine;
-using UnityEngine.ProBuilder.MeshOperations;
 using UnityEngine.SceneManagement;
 
 public class EndLevelMenu : MonoBehaviour
@@ -23,6 +22,7 @@ public class EndLevelMenu : MonoBehaviour
     private bool retrying;
     [SerializeField] private bool IsDemo;
     [SerializeField] private GameObject demoMenu;
+    [SerializeField] private float popupDelay;
     #endregion
 
     #region FUNCTIONS
@@ -44,9 +44,21 @@ public class EndLevelMenu : MonoBehaviour
     /// </summary>
     public void EnableEndMenuUi(bool win)
     {
+        StartCoroutine(DelayedPopup(win));
+    }
+
+    /// <summary>
+    /// shows the end level menu after a delay
+    /// </summary>
+    /// <param name="isWin"></param>
+    /// <returns></returns>
+    private IEnumerator DelayedPopup(bool isWin)
+    {
+        yield return new WaitForSeconds(popupDelay);
+
         if (!IsDemo)
         {
-            if (win)
+            if (isWin)
             {
                 WinMenu.SetActive(true);
             }
@@ -64,9 +76,6 @@ public class EndLevelMenu : MonoBehaviour
         {
             demoMenu.SetActive(true);
         }
-
-        
-        
     }
 
     /// <summary>


### PR DESCRIPTION
added a delay before the end menu pops up. to test: kill enemies or die, see if delay happens. Delay is currently 0.5s (can be changed in the end level menu prefab).