### PR TITLE
Emergency Movement Fix

### DIFF
--- a/Capstone Project/Assets/Scripts/Runes/RuneEvents.cs
+++ b/Capstone Project/Assets/Scripts/Runes/RuneEvents.cs
@@ -1132,7 +1132,10 @@ public class RuneEvents : MonoBehaviour
     {
 
         StopCoroutine("ConfirmationDelay");
-        GetComponent<RuneRangeAndTargeting>().Confirm.interactable = false;
+        if(GetComponent<RuneRangeAndTargeting>().Confirm != null)
+        {
+            GetComponent<RuneRangeAndTargeting>().Confirm.interactable = false;
+        }
 
         if (WaitingOnPath)
         {
@@ -1402,7 +1405,10 @@ public class RuneEvents : MonoBehaviour
     IEnumerator ConfirmationDelay()
     {
         yield return new WaitForSeconds(.2f);
-        GetComponent<RuneRangeAndTargeting>().Confirm.interactable = true;
+        if (GetComponent<RuneRangeAndTargeting>().Confirm != null)
+        {
+            GetComponent<RuneRangeAndTargeting>().Confirm.interactable = true;
+        }
     }
 
     //used for certain wind attacks


### PR DESCRIPTION
TO TEST: Try to move without selecting a spell first. My bad.