### PR TITLE
enemy handler null ref fix

### DIFF
--- a/Capstone Project/Assets/Scripts/Enemy/Base/EnemyHandler.cs
+++ b/Capstone Project/Assets/Scripts/Enemy/Base/EnemyHandler.cs
@@ -99,10 +99,14 @@ public class EnemyHandler : MonoBehaviour
                 //GridManager.RemoveHighlight();
             }
 
-            if (enemies[index] == null)
+            if (index <= enemies.Count - 1)
             {
-                EnemyNullCheck(index);
+                if (enemies[index] == null)
+                {
+                    EnemyNullCheck(index);
+                }
             }
+            
 
             if (enemies[0].playerStats.turnIndicator.activeSelf)
             {
@@ -153,6 +157,10 @@ public class EnemyHandler : MonoBehaviour
         
     }
 
+    /// <summary>
+    /// clears out all the nulls from the enemy list
+    /// </summary>
+    /// <param name="index"></param>
     private void NullCheckWholeEnemyList(int index)
     {
         if (enemies.Count > 0 && index < enemies.Count)
@@ -227,6 +235,9 @@ public class EnemyHandler : MonoBehaviour
         }
     }
 
+    /// <summary>
+    /// called when the player dies
+    /// </summary>
     public void PlayerDied()
     {
         isPlayerDead = true;

--- a/Capstone Project/Assets/Scripts/Enemy/Base/EnemyHandler.cs
+++ b/Capstone Project/Assets/Scripts/Enemy/Base/EnemyHandler.cs
@@ -15,6 +15,7 @@ public class EnemyHandler : MonoBehaviour
     [HideInInspector]public static EnemyHandler Instance { get; private set; }
     public List<Enemy> enemies = new List<Enemy>();
     private static int index = 0;
+    private bool isPlayerDead;
 
     /// <summary>
     /// Make sure that this is a Singleton 
@@ -55,6 +56,7 @@ public class EnemyHandler : MonoBehaviour
     {
         TurnPublicEvents.BeginEnemyTurn += RunNextEnemyTurn;
         PublicEvents.NewLevel += GetNewEnemies;
+        
         PublicEvents.HideDamagePreview += HideDamagePreview;
     }
 
@@ -76,12 +78,30 @@ public class EnemyHandler : MonoBehaviour
     /// </summary>
     public void RunNextEnemyTurn()
     {
-        if (enemies.Count > 0)
+        bool nullcheck = false;
+        for (int i = 0; i < enemies.Count; i++)
+        {
+            if (enemies[i] == null)
+            {
+                nullcheck = true;
+            }
+        }
+        if (nullcheck)
+        {
+            NullCheckWholeEnemyList(0);
+        }
+
+        if (enemies.Count > 0 && !isPlayerDead)
         {
             if (index == 0)
             {
                 GridManager.ClearGhostEntities();
                 //GridManager.RemoveHighlight();
+            }
+
+            if (enemies[index] == null)
+            {
+                EnemyNullCheck(index);
             }
 
             if (enemies[0].playerStats.turnIndicator.activeSelf)
@@ -107,10 +127,7 @@ public class EnemyHandler : MonoBehaviour
                 enemies[index - 1].turnIndicator.SetActive(false);
             }
 
-            if (enemies[index] == null)
-            {
-                EnemyNullCheck(index);
-            }
+            
             enemies[index].turnIndicator.SetActive(true);
             enemies[index].StartEnemyTurn();
             ++index;
@@ -125,10 +142,30 @@ public class EnemyHandler : MonoBehaviour
     /// <param name="index"></param>
     private void EnemyNullCheck(int index)
     {
-        if (enemies[index] == null)
+        if (enemies.Count > 0)
         {
-            enemies.Remove(enemies[index]);
-            EnemyNullCheck(index);
+            if (enemies[index] == null)
+            {
+                enemies.Remove(enemies[index]);
+                EnemyNullCheck(index);
+            }
+        }
+        
+    }
+
+    private void NullCheckWholeEnemyList(int index)
+    {
+        if (enemies.Count > 0 && index < enemies.Count)
+        {
+            if (enemies[index] == null)
+            {
+                enemies.Remove(enemies[index]);
+                NullCheckWholeEnemyList(index);
+            }
+            else
+            {
+                NullCheckWholeEnemyList(index + 1);
+            }
         }
     }
 
@@ -139,6 +176,19 @@ public class EnemyHandler : MonoBehaviour
     /// <param name="enemy"></param>
     public void RemoveEnemy(Enemy enemy)
     {
+        bool nullcheck = false;
+        for (int i = 0; i < enemies.Count; i++)
+        {
+            if (enemies[i] == null)
+            {
+                nullcheck = true;
+            }
+        }
+        if (nullcheck)
+        {
+            NullCheckWholeEnemyList(0);
+        }
+
         enemies.Remove(enemy);
         if (index > 0)
         {
@@ -157,6 +207,8 @@ public class EnemyHandler : MonoBehaviour
 
     private void GetNewEnemies()
     {
+        isPlayerDead = false;
+        index = 0;
         enemies.Clear();
         SetEnemyList();
     }
@@ -173,5 +225,10 @@ public class EnemyHandler : MonoBehaviour
                 enemy.HideDamagePreivew();
             }
         }
+    }
+
+    public void PlayerDied()
+    {
+        isPlayerDead = true;
     }
 }

--- a/Capstone Project/Assets/Scripts/Player/PlayerStats.cs
+++ b/Capstone Project/Assets/Scripts/Player/PlayerStats.cs
@@ -341,6 +341,7 @@ public class PlayerStats : MonoBehaviour
     /// </summary>
     private void EndLevelPopup()
     {
+        FindFirstObjectByType<EnemyHandler>().PlayerDied();
         //UICanvas.SetActive(false);
         EndLevelMenu endLevelMenu = FindFirstObjectByType<EndLevelMenu>();
         //endLevelMenu.SetText("You Died");


### PR DESCRIPTION
fixes the issue with the indexoutofrangeexception

to test - go into the scene and die, restart the level, then play normally. the exception should not pop up when the enemies:

1. die
2. take their turn
3. take damage
4. attack

please let this work