### PR TITLE
Artifact Bug Fixed

### DIFF
--- a/Capstone Project/Assets/Scripts/UI/OutOfCombatMenuScripts/ArtifactNodeBehavior.cs
+++ b/Capstone Project/Assets/Scripts/UI/OutOfCombatMenuScripts/ArtifactNodeBehavior.cs
@@ -70,7 +70,10 @@ public class ArtifactNodeBehavior : MonoBehaviour
 
             UIAudioManager.Instance.UIPickUp(transform);
 
-            RectTransformUtility.ScreenPointToLocalPointInRectangle(rectTransform, mPos, canvas.worldCamera, out offset);
+            //RectTransformUtility.ScreenPointToLocalPointInRectangle(rectTransform, mPos, canvas.worldCamera, out offset);
+
+            rectTransform.anchoredPosition = mPos;
+
             ArtifactManager.RemoveArtifact(artifactData);
             if (slotBehavior != null)
             {
@@ -102,10 +105,12 @@ public class ArtifactNodeBehavior : MonoBehaviour
 
             dragging = false;
 
+            holding = false;
+
             GameObject slot = ArtifactOverSnapLocation();
             if (slot != null)
             {
-                holding = false;
+                
                 rectTransform.position = slot.GetComponent<RectTransform>().position;
                 slotBehavior = slot.GetComponent<SlotBehavior>();
 

--- a/Capstone Project/Assets/Scripts/UI/OutOfCombatMenuScripts/SpellNodeBehavior.cs
+++ b/Capstone Project/Assets/Scripts/UI/OutOfCombatMenuScripts/SpellNodeBehavior.cs
@@ -72,7 +72,10 @@ public class SpellNodeBehavior : MonoBehaviour
 
             UIAudioManager.Instance.UIPickUp(transform);
 
-            RectTransformUtility.ScreenPointToLocalPointInRectangle(rectTransform, mPos, canvas.worldCamera, out offset);
+            //RectTransformUtility.ScreenPointToLocalPointInRectangle(rectTransform, mPos, canvas.worldCamera, out offset);
+
+            rectTransform.anchoredPosition = mPos;
+
             PublicEvents.RuneUnequipped?.Invoke(runeData);
             if (slotBehavior != null)
             {


### PR DESCRIPTION
When you were in the out of combat menu, you were able to pick up multiple artifacts at once and they'd get stuck to the mouse. This should be fixed. To test this, drag an artifact into an artifact slot and try spam clicking it in different spots and see if it gets stuck to the mouse