### PR TITLE
Pip Hitbox Adjusted

### DIFF
--- a/Capstone Project/Assets/PreFabs/Objects/Pip.prefab
+++ b/Capstone Project/Assets/PreFabs/Objects/Pip.prefab
@@ -196,8 +196,8 @@ SphereCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Radius: 2
-  m_Center: {x: 0, y: 0, z: 0}
+  m_Radius: 1.6615508
+  m_Center: {x: 0, y: -1.9841993, z: 0}
 --- !u!114 &61245314903739025
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
The player can now target the tile behind a pip! The pip can still be collected as well. 