### PR TITLE
Pip floor and ceiling 

### DIFF
--- a/Capstone Project/Assets/PreFabs/GameManager.prefab
+++ b/Capstone Project/Assets/PreFabs/GameManager.prefab
@@ -87,6 +87,7 @@ MonoBehaviour:
   MoveActionPoints: 1
   ActionPointsPerTurn: 1
   ActionPointsPerLevel: 3
+  ActionPointCap: 6
 --- !u!114 &7069175424404703298
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -111,6 +112,7 @@ MonoBehaviour:
   - {x: 12, y: 8}
   - {x: 9, y: 12}
   gridToLoad: 0
+  popUp: {fileID: 0}
 --- !u!114 &8767230653786326938
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -144,6 +146,7 @@ MonoBehaviour:
   breakInfLoop: 0
   playerCanvas: {fileID: 0}
   turnIndicatorPrefab: {fileID: 4808714204469960702, guid: 38ace1e574717c043844f9d2c2d144cf, type: 3}
+  outOfCombatMenu: {fileID: 0}
 --- !u!114 &7363244820257217404
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -212,6 +215,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   enableMovement: 0
+  IsMoving: 0
   IsPathing: 0
 --- !u!114 &7056796669355282131
 MonoBehaviour:
@@ -225,7 +229,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6f89f3c4608066d4aa33dc5dd0ba8489, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  maxNumberOfPipsOnField: 3
+  pipFloor: 3
+  pipCeling: 5
   currentSpawnableTiles: []
   pip: {fileID: 5428169340248162634, guid: 7154145b032be8448968ff2838883785, type: 3}
   spawningLocationsPerLevel:

--- a/Capstone Project/Assets/Scripts/PIPS/PipManager.cs
+++ b/Capstone Project/Assets/Scripts/PIPS/PipManager.cs
@@ -21,7 +21,8 @@ public class PipManager : MonoBehaviour
         public List<TileBehaviour> spawningLocations;
     }
 
-    [SerializeField] private int maxNumberOfPipsOnField;
+    [SerializeField] private int pipFloor;
+    [SerializeField] private int pipCeling;
     [SerializeField] private List<TileBehaviour> currentSpawnableTiles;
     [SerializeField] private GameObject pip;
     [SerializeField] private List<SpawnLocations> spawningLocationsPerLevel;
@@ -70,29 +71,57 @@ public class PipManager : MonoBehaviour
     /// </summary>
     public void SpawnPips()
     {
-        List<TileBehaviour> temp = new List<TileBehaviour>(); 
-        while(currentPipsOnField < maxNumberOfPipsOnField)
+        List<TileBehaviour> temp = new List<TileBehaviour>();
+        if(currentPipsOnField < pipFloor)
         {
-            int index = Random.Range(0, currentSpawnableTiles.Count);
-            if(!GridManager.TileIsEmpty(currentSpawnableTiles[index].IndexInGrid) 
-                || hazardTiles.Contains(currentSpawnableTiles[index]))
+            while (currentPipsOnField < pipFloor)
             {
-                continue; 
-            }
-            temp.Add(currentSpawnableTiles[index]);
-            currentSpawnableTiles[index].AddPip(pip);
-            currentSpawnableTiles.Remove(currentSpawnableTiles[index]);
-            
-            ++currentPipsOnField;
-        }
+                int index = Random.Range(0, currentSpawnableTiles.Count);
+                if (!GridManager.TileIsEmpty(currentSpawnableTiles[index].IndexInGrid)
+                    || hazardTiles.Contains(currentSpawnableTiles[index]))
+                {
+                    continue;
+                }
+                temp.Add(currentSpawnableTiles[index]);
+                currentSpawnableTiles[index].AddPip(pip);
+                currentSpawnableTiles.Remove(currentSpawnableTiles[index]);
 
-        foreach (TileBehaviour tileBehaviour in currentSpawnableTiles)
-        {
-            temp.Add(tileBehaviour);
+                ++currentPipsOnField;
+            }
+
+            foreach (TileBehaviour tileBehaviour in currentSpawnableTiles)
+            {
+                temp.Add(tileBehaviour);
+            }
+            currentSpawnableTiles = temp;
+            spawningLocationsPerLevel[currentLevel].spawningLocations = currentSpawnableTiles;
         }
-        currentSpawnableTiles = temp;
-        spawningLocationsPerLevel[currentLevel].spawningLocations = currentSpawnableTiles;
-        TurnPublicEvents.TurnActionComplete?.Invoke(); 
+        else if(currentPipsOnField < pipCeling)
+        {
+            bool spawnedPip = false;
+            while (!spawnedPip)
+            {
+                int index = Random.Range(0, currentSpawnableTiles.Count);
+                if (!GridManager.TileIsEmpty(currentSpawnableTiles[index].IndexInGrid)
+                    || hazardTiles.Contains(currentSpawnableTiles[index]))
+                {
+                    continue;
+                }
+                temp.Add(currentSpawnableTiles[index]);
+                currentSpawnableTiles[index].AddPip(pip);
+                currentSpawnableTiles.Remove(currentSpawnableTiles[index]);
+                spawnedPip = true;
+                ++currentPipsOnField;
+            }
+
+            foreach (TileBehaviour tileBehaviour in currentSpawnableTiles)
+            {
+                temp.Add(tileBehaviour);
+            }
+            currentSpawnableTiles = temp;
+            spawningLocationsPerLevel[currentLevel].spawningLocations = currentSpawnableTiles;
+        }
+        TurnPublicEvents.TurnActionComplete?.Invoke();
     }
 
     private async void SetCurrentSpawnLocations(int i)


### PR DESCRIPTION
Made it so the pips now spawn like the floor ceiling way we talked about. 

If under 3 will spawn pips until you get 3 on field. Then for each turn spawns a pip until you hit the ceiling value (I set as five to start) 

Please test :D

NOTE: I didn't experience it but all pip tiles being blocked when trying to spawn more pips can cause an error or softlock. This is something designers need to work around with but making sure there are plenty of tiles in the pip spawn list to spawn.