### PR TITLE
Damage Preview Numbers

### DIFF
--- a/Capstone Project/Assets/PreFabs/Menus/NewOutOfCombatMenu.prefab
+++ b/Capstone Project/Assets/PreFabs/Menus/NewOutOfCombatMenu.prefab
@@ -5546,6 +5546,7 @@ MonoBehaviour:
   rangeText: {fileID: 3264184657304872358}
   damageText: {fileID: 5945535011972227798}
   descriptionText: {fileID: 6297823918531340487}
+  nsnb: {fileID: 7538678098212127761}
 --- !u!1 &4692364321852891805
 GameObject:
   m_ObjectHideFlags: 0
@@ -6589,6 +6590,7 @@ MonoBehaviour:
   rangeText: {fileID: 7030552312488818558}
   damageText: {fileID: 3484335892622056868}
   descriptionText: {fileID: 1421501840234642984}
+  nsnb: {fileID: 214084824815137901}
 --- !u!1 &5743623188345745286
 GameObject:
   m_ObjectHideFlags: 0

--- a/Capstone Project/Assets/Scripts/Artifacts/ArtifactManager.cs
+++ b/Capstone Project/Assets/Scripts/Artifacts/ArtifactManager.cs
@@ -197,6 +197,8 @@ public class ArtifactManager
             MarkManager.EquipValueChanged(true, artifact.Mark);
             CurrentArtifactWeight += artifact.ArtifactSize;
 
+            PublicEvents.ArtifactChanged?.Invoke();
+
             return true;
         }
         else
@@ -229,6 +231,7 @@ public class ArtifactManager
             UpdateDictionary(artifact.Mark, false);
             MarkManager.EquipValueChanged(false, artifact.Mark);
             CurrentArtifactWeight -= artifact.ArtifactSize;
+            PublicEvents.ArtifactChanged?.Invoke();
         }
         else
         {

--- a/Capstone Project/Assets/Scripts/PublicEvents.cs
+++ b/Capstone Project/Assets/Scripts/PublicEvents.cs
@@ -121,5 +121,7 @@ public static class PublicEvents
 
     public static Action HideDamagePreview;
 
+    public static Action ArtifactChanged;
+
     #endregion
 }

--- a/Capstone Project/Assets/Scripts/Runes/RuneRangeAndTargeting.cs
+++ b/Capstone Project/Assets/Scripts/Runes/RuneRangeAndTargeting.cs
@@ -32,6 +32,7 @@ public class RuneRangeAndTargeting : MonoBehaviour
     bool castNotCanceled = false;
     //canvas for movement/end turn buttons
     GameObject confirmationMenu;
+    private PlayerStats pStat;
 
     private List<Enemy> enemiesInRange = new List<Enemy>();
 
@@ -74,6 +75,11 @@ public class RuneRangeAndTargeting : MonoBehaviour
         PublicEvents.EndCast -= EndPlayerAttackPhase;
         PublicEvents.SpellConfirmed -= OnSpellCastConfirm;
 
+    }
+
+    private void Start()
+    {
+        pStat = FindFirstObjectByType<PlayerStats>();
     }
 
     #endregion INITIALIZATION
@@ -623,35 +629,35 @@ public class RuneRangeAndTargeting : MonoBehaviour
             case (RuneType.Lightning, 4):
                 foreach(Enemy enemy in enemiesInRange)
                 {
-                    enemy.ShowDamagePreview(storedData.RuneDamage);
+                    enemy.ShowDamagePreview(storedData.RuneDamage * pStat.LightningAttackMultiplier);
                     enemy.isShowingPreview = true;
                 }
                 break;
             case(RuneType.Wind, 1):
                 foreach (Enemy enemy in enemiesInRange)
                 {
-                    enemy.ShowDamagePreview(storedData.RuneDamage);
+                    enemy.ShowDamagePreview(storedData.RuneDamage * pStat.WindAttackMultiplier);
                     enemy.isShowingPreview = true;
                 }
                 break;
             case (RuneType.Wind, 2):
                 foreach (Enemy enemy in enemiesInRange)
                 {
-                    enemy.ShowDamagePreview(storedData.RuneDamage);
+                    enemy.ShowDamagePreview(storedData.RuneDamage * pStat.WindAttackMultiplier);
                     enemy.isShowingPreview = true;
                 }
                 break;
             case (RuneType.Wind, 3):
                 foreach (Enemy enemy in enemiesInRange)
                 {
-                    enemy.ShowDamagePreview(storedData.RuneDamage);
+                    enemy.ShowDamagePreview(storedData.RuneDamage * pStat.WindAttackMultiplier);
                     enemy.isShowingPreview = true;
                 }
                 break;
             case (RuneType.Wind, 4):
                 foreach (Enemy enemy in enemiesInRange)
                 {
-                    enemy.ShowDamagePreview(storedData.RuneDamage);
+                    enemy.ShowDamagePreview(storedData.RuneDamage * pStat.WindAttackMultiplier);
                     enemy.isShowingPreview = true;
                 }
                 break;
@@ -683,7 +689,7 @@ public class RuneRangeAndTargeting : MonoBehaviour
                         Enemy enemy = tile.GetComponentInChildren<Enemy>();
                         if (enemy != null)
                         {
-                            enemy.ShowDamagePreview(storedData.RuneDamage);
+                            enemy.ShowDamagePreview(storedData.RuneDamage * pStat.LightningAttackMultiplier);
                             enemy.isShowingPreview = true;
                         }
                     }
@@ -708,7 +714,7 @@ public class RuneRangeAndTargeting : MonoBehaviour
                         Enemy enemy = tile.GetComponentInChildren<Enemy>();
                         if (enemy != null)
                         {
-                            enemy.ShowDamagePreview(storedData.RuneDamage);
+                            enemy.ShowDamagePreview(storedData.RuneDamage * pStat.LightningAttackMultiplier);
                             enemy.isShowingPreview = true;
                         }
 
@@ -723,7 +729,7 @@ public class RuneRangeAndTargeting : MonoBehaviour
                         Enemy enemy = tile.GetComponentInChildren<Enemy>();
                         if (enemy != null)
                         {
-                            enemy.ShowDamagePreview(storedData.RuneDamage);
+                            enemy.ShowDamagePreview(storedData.RuneDamage * pStat.LightningAttackMultiplier);
                             enemy.isShowingPreview = true;
                         }
 
@@ -747,7 +753,7 @@ public class RuneRangeAndTargeting : MonoBehaviour
                         Enemy enemy = tile.GetComponentInChildren<Enemy>();
                         if (enemy != null)
                         {
-                            enemy.ShowDamagePreview(storedData.RuneDamage);
+                            enemy.ShowDamagePreview(storedData.RuneDamage * pStat.LightningAttackMultiplier);
                             enemy.isShowingPreview = true;
                         }
 

--- a/Capstone Project/Assets/Scripts/Runes/RuneRangeAndTargeting.cs
+++ b/Capstone Project/Assets/Scripts/Runes/RuneRangeAndTargeting.cs
@@ -77,6 +77,9 @@ public class RuneRangeAndTargeting : MonoBehaviour
 
     }
 
+    /// <summary>
+    /// Gets a reference to the player's statistcs
+    /// </summary>
     private void Start()
     {
         pStat = FindFirstObjectByType<PlayerStats>();

--- a/Capstone Project/Assets/Scripts/UI/InCombatMenu/SpellDisplayBoxBehavior.cs
+++ b/Capstone Project/Assets/Scripts/UI/InCombatMenu/SpellDisplayBoxBehavior.cs
@@ -5,6 +5,7 @@ Date Last Modified : 2/19/2026
 Brief Description : This is the behavior for the spell display, It sets it up and pops it out
 ***************************************************/
 using TMPro;
+using UnityEditor.Experimental.Rendering;
 using UnityEngine;
 
 public class SpellDisplayBoxBehavior : MonoBehaviour
@@ -29,7 +30,9 @@ public class SpellDisplayBoxBehavior : MonoBehaviour
         if (icsb.rune != null) {
             PopOut();
             spellName.text = icsb.rune.name;
-            spellDamage.text = "Damage: " + icsb.rune.RuneDamage;
+            spellDamage.text = "Damage: " + (int)(icsb.rune.RuneDamage * 
+                (icsb.rune.TypeOfRune == RuneType.Lightning ? FindFirstObjectByType<PlayerStats>().LightningAttackMultiplier 
+                : FindFirstObjectByType<PlayerStats>().WindAttackMultiplier));
             spellDescription.text = icsb.rune.RuneDescription;
 
             int attackPoints = icsb.rune.RuneActionPoints;

--- a/Capstone Project/Assets/Scripts/UI/OutOfCombatMenuScripts/ArtifactNodeBehavior.cs
+++ b/Capstone Project/Assets/Scripts/UI/OutOfCombatMenuScripts/ArtifactNodeBehavior.cs
@@ -158,7 +158,6 @@ public class ArtifactNodeBehavior : MonoBehaviour
                 Destroy(gameObject);
             }
 
-            PublicEvents.ArtifactChanged();
         }
         GetComponent<Image>().raycastTarget = true;
     }

--- a/Capstone Project/Assets/Scripts/UI/OutOfCombatMenuScripts/ArtifactNodeBehavior.cs
+++ b/Capstone Project/Assets/Scripts/UI/OutOfCombatMenuScripts/ArtifactNodeBehavior.cs
@@ -140,6 +140,8 @@ public class ArtifactNodeBehavior : MonoBehaviour
                     transform.SetParent(slot.transform);
                     PublicEvents.RemoveFromStatBox(artifactData);
                 }
+
+                
                 
                 
             }
@@ -155,6 +157,8 @@ public class ArtifactNodeBehavior : MonoBehaviour
                 PublicEvents.RemoveFromStatBox(artifactData);
                 Destroy(gameObject);
             }
+
+            PublicEvents.ArtifactChanged();
         }
         GetComponent<Image>().raycastTarget = true;
     }

--- a/Capstone Project/Assets/Scripts/UI/OutOfCombatMenuScripts/NotebookDescriptionBoxBehavior.cs
+++ b/Capstone Project/Assets/Scripts/UI/OutOfCombatMenuScripts/NotebookDescriptionBoxBehavior.cs
@@ -1,7 +1,7 @@
 /*************************************************
-Author Names : 		Tyler Bouchard
+Author Names : 		Tyler Bouchard, Cade Naylor
 Date Created : 		3/5/2026
-Date Last Modified : 3/5/2026
+Date Last Modified : 4/20/2026
 Brief Description : for updating the description box in the notebook in the in combat menu
 ***************************************************/
 using TMPro;
@@ -15,14 +15,36 @@ public class NotebookDescriptionBoxBehavior : MonoBehaviour
     [SerializeField] private TextMeshProUGUI damageText;
     [SerializeField] private TextMeshProUGUI descriptionText;
 
+    private NotebookSpellNodeBehavior nsnb;
+
+    /// <summary>
+    /// Assigns listeners to public evemts
+    /// </summary>
+    public void OnEnable()
+    {
+        PublicEvents.ArtifactChanged += UpdateDamageNumber;
+    }
+
+    /// <summary>
+    /// Unassigns listeners from public events
+    /// </summary>
+    public void OnDisable()
+    {
+        PublicEvents.ArtifactChanged -= UpdateDamageNumber;
+    }
+
+
+
     /// <summary>
     /// updates the text
     /// </summary>
     /// <param name="node"></param>
     public void SetupTextBox(NotebookSpellNodeBehavior node) {
+        nsnb = node;
         titleText.text = node.runeData.name;
         rangeText.text = "Range: " + node.runeData.RuneRange;
-        damageText.text = "Damage: " + node.runeData.RuneDamage;
+        damageText.text = "Damage: " + (int)(node.runeData.RuneDamage * (node.runeData.TypeOfRune == RuneType.Lightning ? FindFirstObjectByType<PlayerStats>().LightningAttackMultiplier
+                : FindFirstObjectByType<PlayerStats>().WindAttackMultiplier));
         descriptionText.text = node.runeData.RuneDescription;
 
         // setting up the pips
@@ -35,4 +57,18 @@ public class NotebookDescriptionBoxBehavior : MonoBehaviour
             pips[i].SetActive(true);
         }
     }
+
+    /// <summary>
+    /// Updates the spell description damage number to match artifacts
+    /// </summary>
+    /// <param name="ad"></param>
+    public void UpdateDamageNumber()
+    {
+        if (nsnb != null)
+        {
+            damageText.text = "Damage: " + (int)(nsnb.runeData.RuneDamage * (nsnb.runeData.TypeOfRune == RuneType.Lightning ? FindFirstObjectByType<PlayerStats>().LightningAttackMultiplier
+                   : FindFirstObjectByType<PlayerStats>().WindAttackMultiplier));
+        }
+    }
+
 }

--- a/Capstone Project/Assets/Scripts/UI/OutOfCombatMenuScripts/NotebookDescriptionBoxBehavior.cs
+++ b/Capstone Project/Assets/Scripts/UI/OutOfCombatMenuScripts/NotebookDescriptionBoxBehavior.cs
@@ -15,25 +15,15 @@ public class NotebookDescriptionBoxBehavior : MonoBehaviour
     [SerializeField] private TextMeshProUGUI damageText;
     [SerializeField] private TextMeshProUGUI descriptionText;
 
-    private NotebookSpellNodeBehavior nsnb;
+    [SerializeField] private NotebookSpellNodeBehavior nsnb;
 
     /// <summary>
-    /// Assigns listeners to public evemts
+    /// Initializes the Notebook Page
     /// </summary>
-    public void OnEnable()
+    private void Start()
     {
-        PublicEvents.ArtifactChanged += UpdateDamageNumber;
+        SetupTextBox(nsnb);
     }
-
-    /// <summary>
-    /// Unassigns listeners from public events
-    /// </summary>
-    public void OnDisable()
-    {
-        PublicEvents.ArtifactChanged -= UpdateDamageNumber;
-    }
-
-
 
     /// <summary>
     /// updates the text
@@ -41,34 +31,29 @@ public class NotebookDescriptionBoxBehavior : MonoBehaviour
     /// <param name="node"></param>
     public void SetupTextBox(NotebookSpellNodeBehavior node) {
         nsnb = node;
-        titleText.text = node.runeData.name;
-        rangeText.text = "Range: " + node.runeData.RuneRange;
-        damageText.text = "Damage: " + (int)(node.runeData.RuneDamage * (node.runeData.TypeOfRune == RuneType.Lightning ? FindFirstObjectByType<PlayerStats>().LightningAttackMultiplier
+        titleText.text = nsnb.runeData.name;
+        rangeText.text = "Range: " + nsnb.runeData.RuneRange;
+        damageText.text = "Damage: " + (int)(nsnb.runeData.RuneDamage * (nsnb.runeData.TypeOfRune == RuneType.Lightning ? FindFirstObjectByType<PlayerStats>().LightningAttackMultiplier
                 : FindFirstObjectByType<PlayerStats>().WindAttackMultiplier));
-        descriptionText.text = node.runeData.RuneDescription;
+        descriptionText.text = nsnb.runeData.RuneDescription;
 
         // setting up the pips
         foreach (GameObject pip in pips) { 
             pip.SetActive(false);
         }
 
-        for (int i = 0; i < node.runeData.RuneActionPoints; i++)
+        for (int i = 0; i < nsnb.runeData.RuneActionPoints; i++)
         {
             pips[i].SetActive(true);
         }
     }
 
     /// <summary>
-    /// Updates the spell description damage number to match artifacts
+    /// Overloaded function if using the same node
     /// </summary>
-    /// <param name="ad"></param>
-    public void UpdateDamageNumber()
+    public void SetupTextBox()
     {
-        if (nsnb != null)
-        {
-            damageText.text = "Damage: " + (int)(nsnb.runeData.RuneDamage * (nsnb.runeData.TypeOfRune == RuneType.Lightning ? FindFirstObjectByType<PlayerStats>().LightningAttackMultiplier
-                   : FindFirstObjectByType<PlayerStats>().WindAttackMultiplier));
-        }
+        SetupTextBox(nsnb);
     }
 
 }

--- a/Capstone Project/Assets/Scripts/UI/Skill and Equip menu/Artifact Menu/Artifact menu manager.cs
+++ b/Capstone Project/Assets/Scripts/UI/Skill and Equip menu/Artifact Menu/Artifact menu manager.cs
@@ -80,6 +80,7 @@ public class ArtifactMenuManager : MonoBehaviour
     private void OnEnable()
     {
         PublicEvents.TrashHeldOOCObject += ArtifactDropped;
+        PublicEvents.ArtifactChanged += UpdateDamageValues;
     }
 
     /// <summary>
@@ -88,6 +89,7 @@ public class ArtifactMenuManager : MonoBehaviour
     private void OnDisable()
     {
         PublicEvents.TrashHeldOOCObject -= ArtifactDropped;
+        PublicEvents.ArtifactChanged -= UpdateDamageValues;
     }
     #endregion
 
@@ -376,6 +378,20 @@ public class ArtifactMenuManager : MonoBehaviour
 
 
 
+    }
+
+    /// <summary>
+    /// Called when an artifact value is changed
+    /// Updates the description text on all pages
+    /// This is a weird spot for it, but it's always active so it works
+    /// </summary>
+    private void UpdateDamageValues()
+    {
+        NotebookDescriptionBoxBehavior[] ndbb = FindObjectsByType<NotebookDescriptionBoxBehavior>(sortMode:FindObjectsSortMode.None, findObjectsInactive:FindObjectsInactive.Include);
+        foreach(NotebookDescriptionBoxBehavior n in ndbb)
+        {
+            n.SetupTextBox();
+        }
     }
 
     #endregion


### PR DESCRIPTION
Damage numbers should be correct and consistent across the notebook, tooltip in combat, enemy damage preview, and the damage actually dealt for initial rune damage