### PR TITLE
Changes to ending timing

### DIFF
--- a/Capstone Project/Assets/Scripts/Enemy/Base/Enemy.cs
+++ b/Capstone Project/Assets/Scripts/Enemy/Base/Enemy.cs
@@ -30,7 +30,7 @@ public class Enemy : MonoBehaviour
 
     public enum DamageType
     {
-        Lightning, Wind, None
+        Lightning, Wind, Bush, ElectricTile, None
     }
 
 
@@ -265,7 +265,7 @@ public class Enemy : MonoBehaviour
             
             if (currentHealth <= 0)
             {
-                EnemyHandler.Instance.RemoveEnemy(this);
+                EnemyHandler.Instance.RemoveEnemy(this, dType);
                 await Task.Delay(500);
                 Die();
             }

--- a/Capstone Project/Assets/Scripts/Enemy/Base/EnemyHandler.cs
+++ b/Capstone Project/Assets/Scripts/Enemy/Base/EnemyHandler.cs
@@ -184,7 +184,7 @@ public class EnemyHandler : MonoBehaviour
     /// Checks if all enemies are dead if they are end battle
     /// </summary>
     /// <param name="enemy"></param>
-    public void RemoveEnemy(Enemy enemy)
+    public void RemoveEnemy(Enemy enemy, Enemy.DamageType dType)
     {
         bool nullcheck = false;
         for (int i = 0; i < enemies.Count; i++)
@@ -211,7 +211,8 @@ public class EnemyHandler : MonoBehaviour
             EndLevelMenu endLevelMenu = FindFirstObjectByType<EndLevelMenu>();
             //endLevelMenu.SetText("You Beat the Level!");
             //endLevelMenu.SetNextLevelButton(true);
-            endLevelMenu.EnableEndMenuUi(true);
+            bool callInstant = (dType == Enemy.DamageType.Lightning || dType == Enemy.DamageType.Wind);
+            endLevelMenu.EnableEndMenuUi(true, callInstant);
         }
     }
 

--- a/Capstone Project/Assets/Scripts/GridScripts/TileScripts/DamageHazardBehaviour.cs
+++ b/Capstone Project/Assets/Scripts/GridScripts/TileScripts/DamageHazardBehaviour.cs
@@ -32,7 +32,7 @@ public class DamageHazardBehaviour : MonoBehaviour
         if(collision.gameObject.GetComponent<PlayerBehavior>()|| collision.gameObject.GetComponent<Enemy>())
         {
             canDamage = true;
-            GetComponentInParent<TileBehaviour>().DamageEntity(hazardDamage);
+            GetComponentInParent<TileBehaviour>().DamageEntity(hazardDamage, false);
 
             anim.SetTrigger("SteppedOn");
             bushParticles.Play();
@@ -57,7 +57,7 @@ public class DamageHazardBehaviour : MonoBehaviour
     /// </summary>
     public void EndTurnDamage()
     {
-        GetComponentInParent<TileBehaviour>().DamageEntity(hazardDamage);
+        GetComponentInParent<TileBehaviour>().DamageEntity(hazardDamage, false);
 
         anim.SetTrigger("SteppedOn");
     }

--- a/Capstone Project/Assets/Scripts/GridScripts/TileScripts/TileBehaviour.cs
+++ b/Capstone Project/Assets/Scripts/GridScripts/TileScripts/TileBehaviour.cs
@@ -286,7 +286,7 @@ public class TileBehaviour : MonoBehaviour
     public void ApplyTileEffects() {
         if (tileType == TileType.Water && isElectrified) 
         {
-            DamageEntity(damageWhenElectrified);
+            DamageEntity(damageWhenElectrified, true);
         }
     }
 
@@ -306,7 +306,7 @@ public class TileBehaviour : MonoBehaviour
 
         if (tileType == TileType.Water && isElectrified)
         {
-            DamageEntity(damageWhenElectrified);
+            DamageEntity(damageWhenElectrified, true);
             turnsSinceElectrification++;
             if (turnsSinceElectrification >= electrificationDuration)
             {
@@ -356,7 +356,7 @@ public class TileBehaviour : MonoBehaviour
     /// applys the damage to the entities
     /// </summary>
     /// <param name="amount"></param>
-    public void DamageEntity(int amount) {
+    public void DamageEntity(int amount, bool isElectric) {
         //calls the player damage
         if (ObjectOnTile != null) {
             if (ObjectOnTile.GetComponent<PlayerBehavior>() != null)

--- a/Capstone Project/Assets/Scripts/UI/EndLevelMenu.cs
+++ b/Capstone Project/Assets/Scripts/UI/EndLevelMenu.cs
@@ -43,12 +43,19 @@ public class EndLevelMenu : MonoBehaviour
     /// <summary>
     /// Toggles ig the EndMenuUi is on or off 
     /// </summary>
-    public void EnableEndMenuUi(bool win)
+    public void EnableEndMenuUi(bool win, bool delay = true)
     {
         if (!AnyMenuOpen() && !endCalled)
         {
             endCalled = true;
-            StartCoroutine(DelayedPopup(win));
+            if (delay)
+            {
+                StartCoroutine(DelayedPopup(win));
+            }
+            else
+            {
+                InstantPopup(win);
+            }
         }
     }
 
@@ -85,6 +92,39 @@ public class EndLevelMenu : MonoBehaviour
 
         endCalled = false;
     }
+
+    /// <summary>
+    /// Used to call the end level menu without a wait/delay
+    /// </summary>
+    /// <param name="won"></param>
+    private void InstantPopup(bool won)
+    {
+        if (won)
+        {
+            levelsWon++;
+            if (IsDemo && levelsWon == 2)
+            {
+                demoMenu.SetActive(true);
+            }
+            else
+            {
+                WinMenu.SetActive(true);
+            }
+
+
+        }
+        else
+        {
+            LoseMenu.SetActive(true);
+        }
+        if (!WinMenu.activeSelf || !LoseMenu.activeSelf || !demoMenu.activeSelf)
+        {
+            FindFirstObjectByType<TransitionManager>().LevelToEndScreen();
+        }
+
+        endCalled = false;
+    }
+
 
     /// <summary>
     /// Checks if a menu has been activated. Returns false if none are


### PR DESCRIPTION
When the last enemy dies to a bush or electric tile, it pops up the win screen immediately. 
When the last enemy dies to a spell, it waits for a period of time to let the animation finish, then pops up the win screen