### PR TITLE
Fix to the hard lock

### DIFF
--- a/Capstone Project/Assets/PreFabs/NewLevelPrefabs/Level (8x8).prefab
+++ b/Capstone Project/Assets/PreFabs/NewLevelPrefabs/Level (8x8).prefab
@@ -287,8 +287,16 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 2100000, guid: 185ce79413b0b9241b37ebfe197d1b2e, type: 2}
     - target: {fileID: 5244662445083863600, guid: c150d48ba870c3d4f8bb192ecc7ec853, type: 3}
+      propertyPath: entityObject
+      value: 
+      objectReference: {fileID: 6926130306899230273, guid: df00763826453dd44bc77ec4cea75495, type: 3}
+    - target: {fileID: 5244662445083863600, guid: c150d48ba870c3d4f8bb192ecc7ec853, type: 3}
       propertyPath: IndexInGrid.y
       value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 5244662445083863600, guid: c150d48ba870c3d4f8bb192ecc7ec853, type: 3}
+      propertyPath: TileHasEntities
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6649531733221127407, guid: c150d48ba870c3d4f8bb192ecc7ec853, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1562,7 +1570,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5244662445083863600, guid: c150d48ba870c3d4f8bb192ecc7ec853, type: 3}
       propertyPath: TileHasEntities
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6649531733221127407, guid: c150d48ba870c3d4f8bb192ecc7ec853, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2707,8 +2715,16 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4406038969369528828, guid: 928a20b64ccd9b84c935adfa736d89e5, type: 3}
+      propertyPath: entityObject
+      value: 
+      objectReference: {fileID: 6926130306899230273, guid: df00763826453dd44bc77ec4cea75495, type: 3}
+    - target: {fileID: 4406038969369528828, guid: 928a20b64ccd9b84c935adfa736d89e5, type: 3}
       propertyPath: IndexInGrid.x
       value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4406038969369528828, guid: 928a20b64ccd9b84c935adfa736d89e5, type: 3}
+      propertyPath: TileHasEntities
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5845730849051104331, guid: 928a20b64ccd9b84c935adfa736d89e5, type: 3}
       propertyPath: m_Name
@@ -3218,7 +3234,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5244662445083863600, guid: c150d48ba870c3d4f8bb192ecc7ec853, type: 3}
       propertyPath: TileHasEntities
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6649531733221127407, guid: c150d48ba870c3d4f8bb192ecc7ec853, type: 3}
       propertyPath: m_LocalPosition.x


### PR DESCRIPTION
Alright there was a bug with VERY specific steps to recreate it: 

In LVL 1 only. If you ended your SECOND turn in the two rightmost columns in the grid (columns 7 and 8). On the LAST enemies end of turn the game would freeze. If you did not follow the exact steps above the bug would not trigger. 

The fix was moving where enemies spawn so they do not spawn in the rightmost columns. 

Please test that this did fix it.
- If this gets approved I'm so sorry design this is what the lvl 1 layout is 