### PR TITLE
Knockback Wind/WASD Softlock Fix

### DIFF
--- a/Capstone Project/Assets/Scripts/ButtonManager.cs
+++ b/Capstone Project/Assets/Scripts/ButtonManager.cs
@@ -49,6 +49,9 @@ public class ButtonManager : MonoBehaviour
     private GameManager gm; // temp variable
     private TransitionManager tm;
 
+    RuneEvents runeEvents;
+    RuneRangeAndTargeting runeRangeAndTargeting;
+
     private bool isPlayersTurn;
     private bool castingSpell;
 
@@ -65,7 +68,10 @@ public class ButtonManager : MonoBehaviour
         cameraManager = FindFirstObjectByType<CameraManager>();
         gm = FindFirstObjectByType<GameManager>();
         tm = FindFirstObjectByType<TransitionManager>();
-        playerBehavior = FindFirstObjectByType<PlayerBehavior>();        
+        playerBehavior = FindFirstObjectByType<PlayerBehavior>();
+
+        runeEvents = FindFirstObjectByType<RuneEvents>();
+        runeRangeAndTargeting = FindFirstObjectByType<RuneRangeAndTargeting>();
     }
 
     #region functions
@@ -233,22 +239,22 @@ public class ButtonManager : MonoBehaviour
     /// </summary>
     public void ConfirmOnClick()
     {
-        PublicEvents.HideDamagePreview();
 
-        if(!FindFirstObjectByType<RuneEvents>().WaitingOnPath && FindFirstObjectByType<RuneEvents>().Pathing)
+        if ((!runeEvents.WaitingOnPath && runeEvents.Pathing) || runeEvents.Casting)
         {
             return;
         }
 
-        if(FindFirstObjectByType<RuneRangeAndTargeting>().WaitingForThePlayer)
+        PublicEvents.HideDamagePreview();
+
+        if(runeRangeAndTargeting.WaitingForThePlayer)
         {
 
-            if(FindFirstObjectByType<RuneEvents>().WaitingOnPath)
+            if(runeEvents.WaitingOnPath)
             {
 
-                FindFirstObjectByType<RuneRangeAndTargeting>().selectedTile =
-                GridManager.combatGrid[FindFirstObjectByType<RuneEvents>().selectedTile.x, 
-                FindFirstObjectByType<RuneEvents>().selectedTile.y];
+                runeRangeAndTargeting.selectedTile = 
+                GridManager.combatGrid[runeEvents.selectedTile.x, runeEvents.selectedTile.y];
 
             }
 

--- a/Capstone Project/Assets/Scripts/Player/PlayerInputHandler.cs
+++ b/Capstone Project/Assets/Scripts/Player/PlayerInputHandler.cs
@@ -1,7 +1,7 @@
 /*************************************************
 Author Names : 		Tyler Hayes, Jay Embry
 Date Created : 		10/27/2025
-Date Last Modified : 2/15/2026 (Jay Embry)
+Date Last Modified : 4/27/2026 (Jay Embry)
 Brief Description : Handles all of the player's inputs
 External Resources : 	
 ***************************************************/
@@ -34,6 +34,9 @@ public class PlayerInputHandler : MonoBehaviour
 
     private Vector2 movementDirection;
 
+    RuneRangeAndTargeting runeRangeAndTargeting;
+    RuneEvents runeEvents;
+
     #endregion VARS
 
     #region INITIALIZATION
@@ -53,6 +56,8 @@ public class PlayerInputHandler : MonoBehaviour
         movePlayer = pInput.currentActionMap.FindAction("Move");
         toggleGridView = pInput.currentActionMap.FindAction("ToggleGridView");
 
+        runeRangeAndTargeting = FindFirstObjectByType<RuneRangeAndTargeting>();
+        runeEvents = FindFirstObjectByType<RuneEvents>();
 
         mousePressed = false;
         enableMovement = false;
@@ -204,13 +209,14 @@ public class PlayerInputHandler : MonoBehaviour
     /// <param name="obj"></param>
     private void MovePlayer_performed(InputAction.CallbackContext obj)
     {
-
-        if (FindFirstObjectByType<RuneEvents>())
+        if(runeRangeAndTargeting.WaitingForThePlayer && !runeEvents.WaitingOnPath)
         {
-            if (FindFirstObjectByType<RuneEvents>().WaitingOnPath)
-            {
-                IsPathing = true;
-            }
+            return;
+        }
+
+        if (runeEvents.WaitingOnPath)
+        {
+            IsPathing = true;
         }
 
         movementDirection = obj.ReadValue<Vector2>();


### PR DESCRIPTION
Spamming WASD while having Knockback Wind selected and/or while casting Knockback Wind should no longer cause a softlock. This should prevent this issue from happening with any other spells that do not require pathing, too.