### PR TITLE
Phantom movement fix

### DIFF
--- a/Capstone Project/Assets/PreFabs/Player.prefab
+++ b/Capstone Project/Assets/PreFabs/Player.prefab
@@ -1007,7 +1007,7 @@ MonoBehaviour:
   movementSpeed: 5
   movementRange: 6
   allowLeftoverMovement: 1
-  onlyMoveOnce: 0
+  onlyMoveOnce: 1
   previousColliderPos: {x: 0, y: 0, z: 0}
   underEffect: 0
   pTransform: {fileID: 6895680415729585072}


### PR DESCRIPTION
Checked the bool in the player prefab that sets leftover movement to 0. Now when the player doesn't use all their movement, it will say 0 instead of however much they had left.

Test by playing in CopyIB and then moving. Don't use all your movement and then click confirm.